### PR TITLE
allow user to cache image being uploaded to prevent re-download

### DIFF
--- a/lib/src/firebase_cache_manager/base_firebase_cache_manager.dart
+++ b/lib/src/firebase_cache_manager/base_firebase_cache_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:firebase_cached_image/firebase_cached_image.dart';
 import 'package:firebase_cached_image/src/core/cached_object.dart';
 
@@ -74,6 +76,12 @@ abstract class BaseFirebaseCacheManager {
 
   /// Delete specific file from cache
   Future<void> delete(FirebaseUrl firebaseUrl);
+
+  /// Add file to cache
+  ///
+  /// When uploading the item to Firebase Storage, you can also add it to the cache
+  /// This prevents the user from having to download the file again after uploading it
+  Future<void> copyFileToCache(File fileToCache, FirebaseUrl firebaseUrl);
 
   /// Check whether the file is cached or not.
   ///

--- a/lib/src/firebase_cache_manager/mobile_firebase_cache_manager.dart
+++ b/lib/src/firebase_cache_manager/mobile_firebase_cache_manager.dart
@@ -209,6 +209,25 @@ class FirebaseCacheManager extends BaseFirebaseCacheManager {
     ]);
   }
 
+  @override
+  Future<void> copyFileToCache(
+      File fileToCache, FirebaseUrl firebaseUrl,) async {
+    final manager = await _cacheManager;
+    final localPath = await getFullLocalPath(firebaseUrl.uniqueId);
+
+    await Future.wait([
+      fileToCache.copy(localPath),
+      manager.put(
+        CachedObject(
+          id: firebaseUrl.uniqueId,
+          fullLocalPath: localPath,
+          url: firebaseUrl.url.toString(),
+          modifiedAt: DateTime.now().millisecondsSinceEpoch,
+        ),
+      ),
+    ]);
+  }
+
   Future<String> getFullLocalPath(String fileName) async {
     return join(await _cacheDirectoryPath, fileName);
   }

--- a/lib/src/firebase_cache_manager/web_firebase_cache_manager.dart
+++ b/lib/src/firebase_cache_manager/web_firebase_cache_manager.dart
@@ -1,10 +1,12 @@
+import 'dart:io';
+
 import 'package:firebase_cached_image/src/core/cache_options.dart';
 import 'package:firebase_cached_image/src/core/cached_object.dart';
 import 'package:firebase_cached_image/src/core/firebase_url.dart';
 import 'package:firebase_cached_image/src/firebase_cache_manager/base_firebase_cache_manager.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 
-class FirebaseCacheManager extends BaseFirebaseCacheManager {
+class FirebaseCacheManager extends BaseFirebaseCacheManager{
   FirebaseCacheManager({super.subDir});
 
   @override
@@ -27,6 +29,9 @@ class FirebaseCacheManager extends BaseFirebaseCacheManager {
 
   @override
   Future<void> refreshCachedFile(FirebaseUrl firebaseUrl) => Future.value();
+
+  @override
+  Future<void> copyFileToCache(File fileToCache, FirebaseUrl firebaseUrl) => Future.value();
 
   @override
   Future<CachedObject> getSingleObject(


### PR DESCRIPTION
If you are adding items to firebase there should be a way to manually copy the file to cache to prevent download