### PR TITLE
Revamp project structure

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -77,17 +77,17 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: b69516f2c26a5bcac4eee2e32512e1a5205ab312b3536c1c1227b2b942b5f9ad
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "7.0.0"
   firebase_cached_image:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.5.3"
   firebase_core:
     dependency: transitive
     description:
@@ -183,6 +183,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: cdd14e3836065a1f6302a236ec8b5f700695c803c57ae11a1c84df31e6bcf831
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.3"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "9b2ef90589911d665277464e0482b209d39882dffaaf4ef69a3561a3354b2ebc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: fd3cd66cb2bcd7b50dcd3b413af49d78051f809c8b3f6e047962765c15a0d23d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   lints:
     dependency: transitive
     description:
@@ -195,34 +219,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: transitive
     description:
@@ -251,10 +275,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: ab0987bf95bc591da42dffb38c77398fc43309f0b9b894dcc5d6f40c4b26c379
+      sha256: ffbb8cc9ed2c9ec0e4b7a541e56fd79b138e8f47d2fb86815f15358a349b3b57
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
+    version: "2.1.11"
   path_provider_macos:
     dependency: transitive
     description:
@@ -295,14 +319,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -312,10 +328,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   sqflite:
     dependency: transitive
     description:
@@ -336,18 +352,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -376,10 +392,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -404,6 +420,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.0.0"
   win32:
     dependency: transitive
     description:
@@ -416,10 +440,10 @@ packages:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: "060b6e1c891d956f72b5ac9463466c37cce3fa962a921532fc001e86fe93438e"
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0+1"
+    version: "1.0.4"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.2.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/cloud_storage_manager/cloud_storage_manager.dart
+++ b/lib/src/cloud_storage_manager/cloud_storage_manager.dart
@@ -1,0 +1,22 @@
+import 'dart:typed_data';
+
+import 'package:firebase_cached_image/src/core/firebase_url.dart';
+
+class CloudStorageManager {
+  Future<Uint8List?> downloadLatestFile(
+    FirebaseUrl firebaseUrl, [
+    int maxSize = 10485760,
+  ]) {
+    return firebaseUrl.ref.getData(maxSize);
+  }
+
+  Future<bool> isUpdated(
+    FirebaseUrl firebaseUrl,
+    int cachedFileModifiedAt,
+  ) async {
+    final metadata = await firebaseUrl.ref.getMetadata();
+    final lastModified = metadata.updated;
+
+    return (lastModified?.millisecondsSinceEpoch ?? 0) > cachedFileModifiedAt;
+  }
+}

--- a/lib/src/cloud_storage_manager/native_cloud_storage_manage.dart
+++ b/lib/src/cloud_storage_manager/native_cloud_storage_manage.dart
@@ -1,0 +1,15 @@
+import 'package:file/file.dart';
+import 'package:firebase_cached_image/src/cloud_storage_manager/cloud_storage_manager.dart';
+import 'package:firebase_cached_image/src/core/firebase_url.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+
+class NativeCloudStorageManager extends CloudStorageManager {
+  Future<TaskSnapshot> writeToFile(
+    FirebaseUrl firebaseUrl,
+    File file,
+  ) async {
+    final task = await firebaseUrl.ref.writeToFile(file);
+
+    return task;
+  }
+}

--- a/lib/src/cloud_storage_manager/native_cloud_storage_manage.dart
+++ b/lib/src/cloud_storage_manager/native_cloud_storage_manage.dart
@@ -1,15 +1,29 @@
+import 'dart:typed_data';
+
 import 'package:file/file.dart';
 import 'package:firebase_cached_image/src/cloud_storage_manager/cloud_storage_manager.dart';
 import 'package:firebase_cached_image/src/core/firebase_url.dart';
-import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/widgets.dart';
 
 class NativeCloudStorageManager extends CloudStorageManager {
-  Future<TaskSnapshot> writeToFile(
+  //* Dynamic is used to avoid returning DownloadTask in Test class
+  Future<dynamic> writeToFile(
     FirebaseUrl firebaseUrl,
     File file,
-  ) async {
-    final task = await firebaseUrl.ref.writeToFile(file);
+  ) {
+    return firebaseUrl.ref.writeToFile(file);
+  }
+}
 
-    return task;
+@visibleForTesting
+class TestNativeCloudStorageManager extends NativeCloudStorageManager {
+  static final bytes = Uint8List.fromList([1, 2, 3]);
+
+  @override
+  Future<dynamic> writeToFile(
+    FirebaseUrl firebaseUrl,
+    File file,
+  ) {
+    return file.writeAsBytes(bytes);
   }
 }

--- a/lib/src/cloud_storage_manager/native_cloud_storage_manage.dart
+++ b/lib/src/cloud_storage_manager/native_cloud_storage_manage.dart
@@ -1,9 +1,6 @@
-import 'dart:typed_data';
-
 import 'package:file/file.dart';
 import 'package:firebase_cached_image/src/cloud_storage_manager/cloud_storage_manager.dart';
 import 'package:firebase_cached_image/src/core/firebase_url.dart';
-import 'package:flutter/widgets.dart';
 
 class NativeCloudStorageManager extends CloudStorageManager {
   //* Dynamic is used to avoid returning DownloadTask in Test class
@@ -12,18 +9,5 @@ class NativeCloudStorageManager extends CloudStorageManager {
     File file,
   ) {
     return firebaseUrl.ref.writeToFile(file);
-  }
-}
-
-@visibleForTesting
-class TestNativeCloudStorageManager extends NativeCloudStorageManager {
-  static final bytes = Uint8List.fromList([1, 2, 3]);
-
-  @override
-  Future<dynamic> writeToFile(
-    FirebaseUrl firebaseUrl,
-    File file,
-  ) {
-    return file.writeAsBytes(bytes);
   }
 }

--- a/lib/src/db_cache_manager/mobile_db_cache_manager.dart
+++ b/lib/src/db_cache_manager/mobile_db_cache_manager.dart
@@ -9,7 +9,7 @@ import 'package:sqflite/sqflite.dart';
 class MobileDbCacheManager {
   final Future<Database> _db;
 
-  MobileDbCacheManager.init() : _db = _getDb();
+  MobileDbCacheManager() : _db = _getDb();
 
   @visibleForTesting
   static const tableName = "flutter_cached_images";

--- a/lib/src/db_cache_manager/mobile_db_cache_manager.dart
+++ b/lib/src/db_cache_manager/mobile_db_cache_manager.dart
@@ -30,7 +30,7 @@ class MobileDbCacheManager {
   static Future<String> _getDatabasePath() async =>
       join((await getTemporaryDirectory()).path, "$tableName.db");
 
-  Future<List<String>?> clear({Duration? modifiedBefore}) async {
+  Future<List<CachedObject>?> clear({Duration? modifiedBefore}) async {
     final db = await _db;
     if (modifiedBefore != null) {
       final millis =
@@ -40,12 +40,11 @@ class MobileDbCacheManager {
         tableName,
         where: "modifiedAt < ?",
         whereArgs: [millis],
-        columns: ["fullLocalPath"],
       );
 
       await db.delete(tableName, where: "modifiedAt < ?", whereArgs: [millis]);
 
-      return data.map((e) => e['fullLocalPath']! as String).toList();
+      return data.map((e) => CachedObject.fromMap(e)).toList();
     } else {
       await db.delete(tableName);
     }

--- a/lib/src/firebase_cache_manager/mobile_firebase_cache_manager.dart
+++ b/lib/src/firebase_cache_manager/mobile_firebase_cache_manager.dart
@@ -28,7 +28,7 @@ Future<String> _getLocalDir(String _subDir) async {
 
 class FirebaseCacheManager extends BaseFirebaseCacheManager {
   FirebaseCacheManager({super.subDir})
-      : _cacheManager = MobileDbCacheManager.init(),
+      : _cacheManager = SynchronousFuture(MobileDbCacheManager.init()),
         _cacheDirectoryPath = _getLocalDir(subDir ?? kDefaultImageCacheDir);
 
   final Future<MobileDbCacheManager> _cacheManager;

--- a/lib/src/fs_manager/fs_manager.dart
+++ b/lib/src/fs_manager/fs_manager.dart
@@ -1,0 +1,77 @@
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:flutter/widgets.dart';
+import 'package:path_provider/path_provider.dart';
+
+@visibleForTesting
+final cachedAppDirPaths = <String, String>{};
+
+@visibleForTesting
+Future<io.Directory> Function() getTempDir = () {
+  return getTemporaryDirectory();
+};
+
+@visibleForTesting
+Future<String> getLocalDir(String _subDir, FileSystem fs) async {
+  String _localDir;
+
+  if (cachedAppDirPaths.containsKey(_subDir)) {
+    _localDir = cachedAppDirPaths[_subDir]!;
+  } else {
+    final _cacheDir = await getTempDir();
+    _localDir = fs.directory(_cacheDir.path).childDirectory(_subDir).path;
+    cachedAppDirPaths.putIfAbsent(_subDir, () => _localDir);
+  }
+
+  await fs.directory(_localDir).create();
+
+  return _localDir;
+}
+
+class FsManager {
+  final FileSystem _fs;
+  final Future<String> _dirPath;
+
+  FsManager({required String subDir})
+      : _fs = const LocalFileSystem(),
+        _dirPath = getLocalDir(subDir, const LocalFileSystem());
+
+  @visibleForTesting
+  FsManager.test(this._fs, {required String subDir})
+      : _dirPath = getLocalDir(subDir, _fs);
+
+  @visibleForTesting
+  Future<String> get dirPath => _dirPath;
+
+  Future<File> getFile(String fileName) async {
+    final dir = await _dirPath;
+    return _fs.directory(dir).childFile(fileName);
+  }
+
+  Future<File> createFile(String fileName) async {
+    return getFile(fileName).then((file) => file.create());
+  }
+
+  Future<void> deleteFile(String fileName) async {
+    return getFile(fileName).then((file) => file.delete());
+  }
+
+  Future<bool> fileExists(String fileName) async {
+    return getFile(fileName).then((file) => file.exists());
+  }
+
+  Future<void> deleteAllFiles() async {
+    final dir = await _dirPath;
+    final fsDir = _fs.directory(dir);
+
+    await fsDir.delete(recursive: true);
+    await fsDir.create(recursive: true);
+  }
+
+  @visibleForTesting
+  Future<String> getFullLocalPath(String fileName) async {
+    return getFile(fileName).then((file) => file.path);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  file: ^7.0.0
   firebase_core: ">=1.0.0 <3.0.0"
   firebase_storage: ">=10.0.0 <12.0.0"
   flutter:

--- a/test/src/cloud_storage_manager/cloud_storage_manager_test.dart
+++ b/test/src/cloud_storage_manager/cloud_storage_manager_test.dart
@@ -1,0 +1,73 @@
+import 'dart:typed_data';
+
+import 'package:firebase_cached_image/src/cloud_storage_manager/cloud_storage_manager.dart';
+import 'package:firebase_cached_image/src/core/firebase_url.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'cloud_storage_manager_test.mocks.dart';
+
+@GenerateMocks([FirebaseUrl, FullMetadata, Reference])
+void main() {
+  final mockFirebaseUrl = MockFirebaseUrl();
+  final mockMetadata = MockFullMetadata();
+  final cloudStorageManager = CloudStorageManager();
+  final mockRef = MockReference();
+
+  setUpAll(() {
+    when(mockFirebaseUrl.ref).thenReturn(mockRef);
+  });
+
+  test('downloadLatestFile returns correct data', () async {
+    when(mockRef.getData(any))
+        .thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
+
+    final result =
+        await cloudStorageManager.downloadLatestFile(mockFirebaseUrl);
+
+    expect(result, equals(Uint8List.fromList([1, 2, 3])));
+  });
+
+  test('isUpdated returns true when cloud file is newer', () async {
+    when(mockRef.getMetadata()).thenAnswer((_) async => mockMetadata);
+    final nowDate = DateTime.now();
+    when(mockMetadata.updated).thenReturn(nowDate);
+
+    final result = await cloudStorageManager.isUpdated(
+      mockFirebaseUrl,
+      nowDate.millisecondsSinceEpoch - 1000,
+    );
+
+    expect(result, equals(true));
+  });
+
+  test('isUpdated returns false when cloud file is older', () async {
+    when(mockRef.getMetadata()).thenAnswer((_) async => mockMetadata);
+
+    final nowDate = DateTime.now();
+    when(mockMetadata.updated).thenReturn(nowDate);
+
+    final result = await cloudStorageManager.isUpdated(
+      mockFirebaseUrl,
+      nowDate.millisecondsSinceEpoch + 1000,
+    );
+
+    expect(result, equals(false));
+  });
+
+  test('isUpdated returns false when cloud file is same', () async {
+    when(mockRef.getMetadata()).thenAnswer((_) async => mockMetadata);
+
+    final nowDate = DateTime.now();
+    when(mockMetadata.updated).thenReturn(nowDate);
+
+    final result = await cloudStorageManager.isUpdated(
+      mockFirebaseUrl,
+      nowDate.millisecondsSinceEpoch,
+    );
+
+    expect(result, equals(false));
+  });
+}

--- a/test/src/db_cache_manager/mobile_db_cache_manager_test.dart
+++ b/test/src/db_cache_manager/mobile_db_cache_manager_test.dart
@@ -179,7 +179,7 @@ void main() {
       const modifiedBefore = Duration(minutes: 10);
       final modifiedTime = dateTime.subtract(modifiedBefore);
 
-      final dbDeletedPaths =
+      final dbDeletedObjects =
           await manager.clear(modifiedBefore: modifiedBefore);
 
       final deletedObjects = objects
@@ -188,11 +188,11 @@ void main() {
           )
           .toList();
 
-      expect(deletedObjects.length, dbDeletedPaths?.length);
+      expect(deletedObjects.length, dbDeletedObjects?.length);
 
       expect(
-        deletedObjects.map((e) => e.fullLocalPath).toSet(),
-        dbDeletedPaths?.toSet(),
+        deletedObjects.toSet(),
+        dbDeletedObjects?.toSet(),
       );
     });
 

--- a/test/src/db_cache_manager/mobile_db_cache_manager_test.dart
+++ b/test/src/db_cache_manager/mobile_db_cache_manager_test.dart
@@ -42,7 +42,7 @@ void main() {
     databaseFactory = databaseFactoryFfi;
     db = await openDatabase(inMemoryDatabasePath);
     await MobileDbCacheManager.createDb(db, 1);
-    manager = MobileDbCacheManager.test(db);
+    manager = MobileDbCacheManager.test(Future.value(db));
   });
 
   test('cache hit', () async {

--- a/test/src/firebase_cache_manager/mobile_firebase_cache_manager_test.dart
+++ b/test/src/firebase_cache_manager/mobile_firebase_cache_manager_test.dart
@@ -58,7 +58,7 @@ void main() {
   //* Test the downloadToCache method
   test("downloadToCache", () async {
     final url = FirebaseUrl.fromReference(ref);
-    final bytes = TestNativeCloudStorageManager.bytes;
+    final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
     when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
       (i) => (i.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -81,7 +81,7 @@ void main() {
   group("getSingleObject ", () {
     test("when the source is Source.server", () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.downloadLatestFile(url))
           .thenAnswer((_) async => bytes);
@@ -105,7 +105,7 @@ void main() {
     //* When the source is Source.cacheServer
     test("when the source is Source.cacheServer", () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.downloadLatestFile(url))
           .thenAnswer((_) async => bytes);
@@ -133,7 +133,7 @@ void main() {
         "when the source is Source.cacheServer on first it should download the file on next call it should get the file from the cache",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.downloadLatestFile(url))
           .thenAnswer((_) async => bytes);
@@ -177,7 +177,7 @@ void main() {
         "when the source is Source.cacheServer and checkForMetadataChange is true and the file is not updated",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
         (_) async => bytes,
@@ -224,7 +224,7 @@ void main() {
         "when the source is Source.cacheServer and checkForMetadataChange is true and the file is updated",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
         (_) async => bytes,
@@ -265,6 +265,8 @@ void main() {
 
       //* On next call it should download the file
       verify(cloudStorageManager.downloadLatestFile(url)).called(1);
+      verify(cloudStorageManager.isUpdated(url, cachedObject.modifiedAt))
+          .called(1);
 
       expect(cachedObject2.id, url.uniqueId);
       expect(cachedObject2.rawData, bytes2);
@@ -285,7 +287,7 @@ void main() {
     //* When the source is Source.server
     test("when the source is Source.server", () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -308,7 +310,7 @@ void main() {
         "when the source is Source.cacheServer on first it should download the file on next call it should get the file from the cache",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -342,7 +344,7 @@ void main() {
         "when the source is Source.cacheServer and checkForMetadataChange is true and the file is not updated",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -385,7 +387,7 @@ void main() {
         "when the source is Source.cacheServer and checkForMetadataChange is true and the file is updated",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -441,7 +443,7 @@ void main() {
         "when the source is Source.cacheServer and db has the file but the file is not present in the cache",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -495,7 +497,7 @@ void main() {
     test("when file is not present in the cache it should download latest file",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -509,7 +511,7 @@ void main() {
     test("when file is present in the cache it should not download the file",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -529,7 +531,7 @@ void main() {
         "when the file is not present in the cache it should download the file",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -545,7 +547,7 @@ void main() {
         "when the file is present in the cache but not updated on the server it should not download the file",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -567,7 +569,7 @@ void main() {
         "when the file is present in the cache and updated on the server it should download the file",
         () async {
       final url = FirebaseUrl.fromReference(ref);
-      final bytes = TestNativeCloudStorageManager.bytes;
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
       when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
         (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
@@ -600,7 +602,7 @@ void main() {
   //* Test the isCached method
   test("isCached", () async {
     final url = FirebaseUrl.fromReference(ref);
-    final bytes = TestNativeCloudStorageManager.bytes;
+    final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
     when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
       (_) async => bytes,
@@ -620,7 +622,7 @@ void main() {
   //* Test the delete method
   test("delete", () async {
     final url = FirebaseUrl.fromReference(ref);
-    final bytes = TestNativeCloudStorageManager.bytes;
+    final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
 
     when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
       (_) async => bytes,

--- a/test/src/firebase_cache_manager/mobile_firebase_cache_manager_test.dart
+++ b/test/src/firebase_cache_manager/mobile_firebase_cache_manager_test.dart
@@ -8,16 +8,20 @@ import 'package:firebase_cached_image/src/db_cache_manager/mobile_db_cache_manag
 import 'package:firebase_cached_image/src/firebase_cache_manager/mobile_firebase_cache_manager.dart';
 import 'package:firebase_cached_image/src/fs_manager/fs_manager.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import '../cloud_storage_manager/cloud_storage_manager_test.mocks.dart';
+import 'mobile_firebase_cache_manager_test.mocks.dart';
 
+@GenerateMocks([NativeCloudStorageManager])
 void main() {
   late Database db;
   late MobileDbCacheManager manager;
-  late NativeCloudStorageManager cloudStorageManager;
+  late MockNativeCloudStorageManager cloudStorageManager;
   late FileSystem fs;
   late FsManager fsManager;
   late FirebaseCacheManager cacheManager;
@@ -33,7 +37,7 @@ void main() {
     db = await openDatabase(inMemoryDatabasePath);
     await MobileDbCacheManager.createDb(db, 1);
     manager = MobileDbCacheManager.test(Future.value(db));
-    cloudStorageManager = TestNativeCloudStorageManager();
+    cloudStorageManager = MockNativeCloudStorageManager();
     fs = MemoryFileSystem.test();
     getTempDir = () async => fs.systemTempDirectory;
 
@@ -55,6 +59,10 @@ void main() {
   test("downloadToCache", () async {
     final url = FirebaseUrl.fromReference(ref);
     final bytes = TestNativeCloudStorageManager.bytes;
+
+    when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+      (i) => (i.positionalArguments[1] as File).writeAsBytes(bytes),
+    );
 
     final filePath = await cacheManager.downloadToCache(url);
 
@@ -163,6 +171,472 @@ void main() {
       expect(cachedObject2.url, url.url.toString());
       expect(cachedObject2.modifiedAt, isNotNull);
     });
+
+    //* When the source is Source.cacheServer and checkForMetadataChange is true and the file is not updated
+    test(
+        "when the source is Source.cacheServer and checkForMetadataChange is true and the file is not updated",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
+        (_) async => bytes,
+      );
+
+      final cachedObject = await cacheManager.getSingleObject(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      expect(cachedObject.id, url.uniqueId);
+      expect(cachedObject.rawData, bytes);
+      expect(cachedObject.url, url.url.toString());
+      expect(cachedObject.modifiedAt, isNotNull);
+
+      verify(cloudStorageManager.downloadLatestFile(url)).called(1);
+
+      when(cloudStorageManager.isUpdated(url, cachedObject.modifiedAt))
+          .thenAnswer((_) async => false);
+
+      final cachedObject2 = await cacheManager.getSingleObject(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      //* On next call it should get the file from the cache
+      verifyNever(cloudStorageManager.downloadLatestFile(url));
+      expect(cachedObject2.modifiedAt, cachedObject.modifiedAt);
+      expect(cachedObject2.id, cachedObject.id);
+      expect(listEquals(cachedObject.rawData, cachedObject2.rawData), isTrue);
+      expect(cachedObject2.url, cachedObject.url);
+    });
+
+    //* When the source is Source.cacheServer and checkForMetadataChange is true and the file is updated
+    test(
+        "when the source is Source.cacheServer and checkForMetadataChange is true and the file is updated",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
+        (_) async => bytes,
+      );
+
+      final cachedObject = await cacheManager.getSingleObject(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      verify(cloudStorageManager.downloadLatestFile(url)).called(1);
+      expect(cachedObject.id, url.uniqueId);
+      expect(cachedObject.rawData, bytes);
+      expect(cachedObject.url, url.url.toString());
+      expect(cachedObject.modifiedAt, isNotNull);
+
+      when(cloudStorageManager.isUpdated(url, cachedObject.modifiedAt))
+          .thenAnswer((_) async => true);
+
+      final bytes2 = Uint8List.fromList([1, 2, 3, 4, 5, 6]);
+
+      when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
+        (_) async => bytes2,
+      );
+
+      final cachedObject2 = await cacheManager.getSingleObject(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      //* On next call it should download the file
+      verify(cloudStorageManager.downloadLatestFile(url)).called(1);
+
+      expect(cachedObject2.id, url.uniqueId);
+      expect(cachedObject2.rawData, bytes2);
+      expect(cachedObject2.url, url.url.toString());
+      expect(cachedObject2.modifiedAt, isNotNull);
+
+      //* The modifiedAt should be greater than the previous one
+      expect(cachedObject2.modifiedAt > cachedObject.modifiedAt, isTrue);
+    });
+
+    tearDown(() async {
+      await db.delete(MobileDbCacheManager.tableName);
+      await fsManager.deleteAllFiles();
+    });
+  });
+
+  group("getSingleFile", () {
+    //* When the source is Source.server
+    test("when the source is Source.server", () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      final filePath = await cacheManager.getSingleFile(
+        url,
+        options: const CacheOptions(source: Source.server),
+      );
+
+      final file = fs.file(filePath);
+
+      expect(await file.exists(), isTrue);
+      expect(await file.readAsBytes(), equals(bytes));
+    });
+
+    //* When the source is Source.cacheServer on first it should download the file on next call it should get the file from the cache
+
+    test(
+        "when the source is Source.cacheServer on first it should download the file on next call it should get the file from the cache",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      final filePath = await cacheManager.getSingleFile(
+        url,
+        // ignore: avoid_redundant_argument_values
+        options: const CacheOptions(source: Source.cacheServer),
+      );
+
+      final file = fs.file(filePath);
+
+      expect(await file.exists(), isTrue);
+      expect(await file.readAsBytes(), equals(bytes));
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+
+      final filePath2 = await cacheManager.getSingleFile(
+        url,
+        // ignore: avoid_redundant_argument_values
+        options: const CacheOptions(source: Source.cacheServer),
+      );
+
+      verifyNever(cloudStorageManager.writeToFile(url, any));
+      expect(filePath2, equals(filePath));
+    });
+
+    //* When the source is Source.cacheServer and checkForMetadataChange is true and the file is not updated
+
+    test(
+        "when the source is Source.cacheServer and checkForMetadataChange is true and the file is not updated",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      final filePath = await cacheManager.getSingleFile(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      final file = fs.file(filePath);
+
+      expect(await file.exists(), isTrue);
+      expect(await file.readAsBytes(), equals(bytes));
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+
+      when(cloudStorageManager.isUpdated(url, any))
+          .thenAnswer((_) async => false);
+
+      final filePath2 = await cacheManager.getSingleFile(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      verifyNever(cloudStorageManager.writeToFile(url, any));
+      expect(filePath2, equals(filePath));
+    });
+
+    //* When the source is Source.cacheServer and checkForMetadataChange is true and the file is updated
+
+    test(
+        "when the source is Source.cacheServer and checkForMetadataChange is true and the file is updated",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      final filePath = await cacheManager.getSingleFile(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      final file = fs.file(filePath);
+      final previousFileStat = file.statSync();
+
+      expect(await file.exists(), isTrue);
+      expect(await file.readAsBytes(), equals(bytes));
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+
+      when(cloudStorageManager.isUpdated(url, any))
+          .thenAnswer((_) async => true);
+
+      final bytes2 = Uint8List.fromList([1, 2, 3, 4, 5, 6]);
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async =>
+            (inv.positionalArguments[1] as File).writeAsBytes(bytes2),
+      );
+
+      final filePath2 = await cacheManager.getSingleFile(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+
+      expect(filePath2, filePath);
+      expect(
+        previousFileStat.modified.isBefore(file.statSync().modified),
+        isTrue,
+      );
+      expect(await file.readAsBytes(), equals(bytes2));
+    });
+
+    //* When the source is Source.cacheServer and db has the file but the file is not present in the cache
+    test(
+        "when the source is Source.cacheServer and db has the file but the file is not present in the cache",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      final filePath = await cacheManager.getSingleFile(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      final file = fs.file(filePath);
+
+      expect(await file.exists(), isTrue);
+      expect(await file.readAsBytes(), equals(bytes));
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+
+      final cachedObject = await manager.get(url.uniqueId);
+
+      expect(cachedObject, isNotNull);
+
+      await fsManager.deleteAllFiles();
+
+      final filePath2 = await cacheManager.getSingleFile(
+        url,
+        options: const CacheOptions(
+          // ignore: avoid_redundant_argument_values
+          source: Source.cacheServer,
+          checkForMetadataChange: true,
+        ),
+      );
+
+      final file2 = fs.file(filePath2);
+
+      expect(await file2.exists(), isTrue);
+      expect(await file2.readAsBytes(), equals(bytes));
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+    });
+
+    tearDown(() async {
+      await db.delete(MobileDbCacheManager.tableName);
+      await fsManager.deleteAllFiles();
+    });
+  });
+
+  //* Test the preCacheFile method
+  group("preCacheFile", () {
+    test("when file is not present in the cache it should download latest file",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      await cacheManager.preCacheFile(url);
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+    });
+
+    //* When the file is present in the cache
+    test("when file is present in the cache it should not download the file",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      await cacheManager.preCacheFile(url);
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+
+      await cacheManager.preCacheFile(url);
+      verifyNever(cloudStorageManager.writeToFile(url, any));
+    });
+  });
+
+  group("refreshCachedFile", () {
+    //* When the file is not present in the cache
+    test(
+        "when the file is not present in the cache it should download the file",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      await cacheManager.refreshCachedFile(url);
+
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+    });
+
+    //* When the file is present in the cache but not updated on the server
+    test(
+        "when the file is present in the cache but not updated on the server it should not download the file",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      await cacheManager.preCacheFile(url);
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+
+      when(cloudStorageManager.isUpdated(url, any))
+          .thenAnswer((_) async => false);
+
+      await cacheManager.refreshCachedFile(url);
+
+      verifyNever(cloudStorageManager.writeToFile(url, any));
+    });
+
+    //* When the file is present in the cache and updated on the server
+    test(
+        "when the file is present in the cache and updated on the server it should download the file",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async => (inv.positionalArguments[1] as File).writeAsBytes(bytes),
+      );
+
+      await cacheManager.preCacheFile(url);
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+
+      when(cloudStorageManager.isUpdated(url, any))
+          .thenAnswer((_) async => true);
+
+      final bytes2 = Uint8List.fromList([1, 2, 3, 4, 5, 6]);
+
+      when(cloudStorageManager.writeToFile(url, any)).thenAnswer(
+        (inv) async =>
+            (inv.positionalArguments[1] as File).writeAsBytes(bytes2),
+      );
+
+      await cacheManager.refreshCachedFile(url);
+
+      verify(cloudStorageManager.writeToFile(url, any)).called(1);
+    });
+
+    tearDown(() async {
+      await db.delete(MobileDbCacheManager.tableName);
+      await fsManager.deleteAllFiles();
+    });
+  });
+
+  //* Test the isCached method
+  test("isCached", () async {
+    final url = FirebaseUrl.fromReference(ref);
+    final bytes = TestNativeCloudStorageManager.bytes;
+
+    when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
+      (_) async => bytes,
+    );
+
+    final isCached = await cacheManager.isCached(url);
+
+    expect(isCached, isFalse);
+
+    await cacheManager.getSingleObject(url);
+
+    final isCached2 = await cacheManager.isCached(url);
+
+    expect(isCached2, isTrue);
+  });
+
+  //* Test the delete method
+  test("delete", () async {
+    final url = FirebaseUrl.fromReference(ref);
+    final bytes = TestNativeCloudStorageManager.bytes;
+
+    when(cloudStorageManager.downloadLatestFile(url)).thenAnswer(
+      (_) async => bytes,
+    );
+
+    await cacheManager.getSingleObject(url);
+
+    final isCached = await cacheManager.isCached(url);
+
+    expect(isCached, isTrue);
+
+    await cacheManager.delete(url);
+
+    final isCached2 = await cacheManager.isCached(url);
+
+    expect(isCached2, isFalse);
   });
 
   tearDown(() async {

--- a/test/src/firebase_cache_manager/mobile_firebase_cache_manager_test.dart
+++ b/test/src/firebase_cache_manager/mobile_firebase_cache_manager_test.dart
@@ -1,0 +1,176 @@
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:firebase_cached_image/src/cloud_storage_manager/native_cloud_storage_manage.dart';
+import 'package:firebase_cached_image/src/core/cache_options.dart';
+import 'package:firebase_cached_image/src/core/firebase_url.dart';
+import 'package:firebase_cached_image/src/core/source.dart';
+import 'package:firebase_cached_image/src/db_cache_manager/mobile_db_cache_manager.dart';
+import 'package:firebase_cached_image/src/firebase_cache_manager/mobile_firebase_cache_manager.dart';
+import 'package:firebase_cached_image/src/fs_manager/fs_manager.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../cloud_storage_manager/cloud_storage_manager_test.mocks.dart';
+
+void main() {
+  late Database db;
+  late MobileDbCacheManager manager;
+  late NativeCloudStorageManager cloudStorageManager;
+  late FileSystem fs;
+  late FsManager fsManager;
+  late FirebaseCacheManager cacheManager;
+  late Reference ref;
+
+  const subDir = "test";
+  const bucket = "bucket";
+  const fullPath = "userpic.jpg";
+
+  setUpAll(() async {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+    db = await openDatabase(inMemoryDatabasePath);
+    await MobileDbCacheManager.createDb(db, 1);
+    manager = MobileDbCacheManager.test(Future.value(db));
+    cloudStorageManager = TestNativeCloudStorageManager();
+    fs = MemoryFileSystem.test();
+    getTempDir = () async => fs.systemTempDirectory;
+
+    fsManager = FsManager.test(fs, subDir: subDir);
+    cacheManager = FirebaseCacheManager.test(
+      cacheManager: manager,
+      fs: fsManager,
+      cloudStorageManager: cloudStorageManager,
+    );
+  });
+
+  setUp(() {
+    ref = MockReference();
+    when(ref.fullPath).thenReturn(fullPath);
+    when(ref.bucket).thenReturn(bucket);
+  });
+
+  //* Test the downloadToCache method
+  test("downloadToCache", () async {
+    final url = FirebaseUrl.fromReference(ref);
+    final bytes = TestNativeCloudStorageManager.bytes;
+
+    final filePath = await cacheManager.downloadToCache(url);
+
+    final file = fs.file(filePath);
+
+    expect(await file.exists(), isTrue);
+    expect(await file.readAsBytes(), equals(bytes));
+
+    final cachedObject = await manager.get(url.uniqueId);
+
+    expect(cachedObject, isNotNull);
+    expect(cachedObject!.id, url.uniqueId);
+  });
+
+  //* Test the getSingleObject method group with multiple test cases
+  group("getSingleObject ", () {
+    test("when the source is Source.server", () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.downloadLatestFile(url))
+          .thenAnswer((_) async => bytes);
+
+      final cachedObject = await cacheManager.getSingleObject(
+        url,
+        options: const CacheOptions(source: Source.server),
+      );
+
+      expect(cachedObject.id, url.uniqueId);
+      expect(cachedObject.rawData, bytes);
+      expect(cachedObject.url, url.url.toString());
+      expect(cachedObject.modifiedAt, isNotNull);
+
+      final file = await fsManager.getFile(url.uniqueId);
+
+      //* File should not exist in the cache
+      expect(await file.exists(), isFalse);
+    });
+
+    //* When the source is Source.cacheServer
+    test("when the source is Source.cacheServer", () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.downloadLatestFile(url))
+          .thenAnswer((_) async => bytes);
+
+      final cachedObject = await cacheManager.getSingleObject(
+        url,
+        // ignore: avoid_redundant_argument_values
+        options: const CacheOptions(source: Source.cacheServer),
+      );
+
+      expect(cachedObject.id, url.uniqueId);
+      expect(cachedObject.rawData, bytes);
+      expect(cachedObject.url, url.url.toString());
+      expect(cachedObject.modifiedAt, isNotNull);
+
+      final file = await fsManager.getFile(url.uniqueId);
+
+      //* File should exist in the cache
+      expect(await file.exists(), isTrue);
+      expect(file.readAsBytesSync(), equals(bytes));
+    });
+
+    //* When the source is Source.cacheServer on first it should download the file on next call it should get the file from the cache
+    test(
+        "when the source is Source.cacheServer on first it should download the file on next call it should get the file from the cache",
+        () async {
+      final url = FirebaseUrl.fromReference(ref);
+      final bytes = TestNativeCloudStorageManager.bytes;
+
+      when(cloudStorageManager.downloadLatestFile(url))
+          .thenAnswer((_) async => bytes);
+
+      final cachedObject = await cacheManager.getSingleObject(
+        url,
+        // ignore: avoid_redundant_argument_values
+        options: const CacheOptions(source: Source.cacheServer),
+      );
+
+      expect(cachedObject.id, url.uniqueId);
+      expect(cachedObject.rawData, equals(bytes));
+      expect(cachedObject.url, url.url.toString());
+      expect(cachedObject.modifiedAt, isNotNull);
+
+      //* On first call it should download the file
+      verify(cloudStorageManager.downloadLatestFile(url)).called(1);
+
+      final file = await fsManager.getFile(url.uniqueId);
+
+      //* File should exist in the cache
+      expect(await file.exists(), isTrue);
+      expect(file.readAsBytesSync(), equals(bytes));
+
+      final cachedObject2 = await cacheManager.getSingleObject(
+        url,
+        // ignore: avoid_redundant_argument_values
+        options: const CacheOptions(source: Source.cacheServer),
+      );
+
+      //* On next call it should get the file from the cache
+      verifyNever(cloudStorageManager.downloadLatestFile(url));
+      expect(cachedObject2.id, url.uniqueId);
+      expect(cachedObject2.rawData, bytes);
+      expect(cachedObject2.url, url.url.toString());
+      expect(cachedObject2.modifiedAt, isNotNull);
+    });
+  });
+
+  tearDown(() async {
+    await db.delete(MobileDbCacheManager.tableName);
+    await fsManager.deleteAllFiles();
+  });
+
+  tearDownAll(() {
+    db.close();
+  });
+}

--- a/test/src/fs_manager/fs_manager_test.dart
+++ b/test/src/fs_manager/fs_manager_test.dart
@@ -1,0 +1,105 @@
+import 'package:file/memory.dart';
+import 'package:firebase_cached_image/src/fs_manager/fs_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  group('FsManager', () {
+    late FsManager fsManager;
+    late MemoryFileSystem fs;
+    const subDir = 'test';
+
+    setUp(() {
+      fs = MemoryFileSystem();
+      getTempDir = () async => fs.systemTempDirectory;
+      fsManager = FsManager.test(fs, subDir: subDir);
+    });
+
+    tearDown(() {
+      cachedAppDirPaths.clear();
+    });
+
+    test('getFile', () async {
+      final file = await fsManager.getFile('test.txt');
+      expect(file.path, contains(subDir));
+      expect(file.path, contains('test.txt'));
+    });
+
+    test('createFile', () async {
+      final file = await fsManager.createFile('test.txt');
+      expect(file.path, contains(subDir));
+      expect(file.path, contains('test.txt'));
+      expect(await file.exists(), isTrue);
+    });
+
+    test('deleteFile', () async {
+      final file = await fsManager.createFile('test.txt');
+      expect(await file.exists(), isTrue);
+
+      await fsManager.deleteFile('test.txt');
+      expect(await file.exists(), isFalse);
+    });
+
+    test('getTempDir', () async {
+      final tempDir = await getTempDir();
+      expect(tempDir.path, contains('tmp'));
+    });
+
+    test('getLocalDir', () async {
+      final localDir = await getLocalDir(subDir, fs);
+
+      expect(fs.directory(localDir).existsSync(), isTrue);
+      expect(localDir, contains(subDir));
+    });
+
+    test('getLocalDir with cachedAppDirPaths', () async {
+      cachedAppDirPaths.clear();
+      int counter = 0;
+      getTempDir = () async {
+        counter++;
+        return fs.systemTempDirectory;
+      };
+
+      final localDir = await getLocalDir(subDir, fs);
+      final cachedLocalDir = await getLocalDir(subDir, fs);
+      expect(localDir, equals(cachedLocalDir));
+      expect(cachedAppDirPaths.length, 1);
+      expect(counter, 1); // Second hit must be catched value
+    });
+
+    test('FsManager`s dir path', () async {
+      final dirPath = await fsManager.dirPath;
+      expect(path.basename(dirPath), contains(subDir));
+    });
+
+    test('File exists', () async {
+      final file = await fsManager.createFile('test.txt');
+      expect(await fsManager.fileExists('test.txt'), isTrue);
+
+      await fsManager.deleteFile('test.txt');
+      expect(await fsManager.fileExists('test.txt'), isFalse);
+    });
+
+    test('deleteAllFiles', () async {
+      await fsManager.createFile('test1.txt');
+      await fsManager.createFile('test2.txt');
+      await fsManager.createFile('test3.txt');
+
+      expect(await fsManager.fileExists('test1.txt'), isTrue);
+      expect(await fsManager.fileExists('test2.txt'), isTrue);
+      expect(await fsManager.fileExists('test3.txt'), isTrue);
+
+      await fsManager.deleteAllFiles();
+
+      expect(await fsManager.fileExists('test1.txt'), isFalse);
+      expect(await fsManager.fileExists('test2.txt'), isFalse);
+      expect(await fsManager.fileExists('test3.txt'), isFalse);
+    });
+
+    test('FsManager with different subDir', () async {
+      final fsManager2 = FsManager.test(fs, subDir: 'test2');
+      final dirPath = await fsManager2.dirPath;
+      expect(path.basename(dirPath), contains('test2'));
+    });
+  });
+}


### PR DESCRIPTION
Project structure revamped. 

FirebaseCacheManager now uses three manager classes, `FsManager`, `CloudStorageManager` and `DbCacheManager` for different operations. It's done to easily unit tests the package and to split the logic. 