### PR TITLE
ignore deprecated_member_use_from_same_package

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,7 +6,9 @@ include: package:lint/analysis_options.yaml
 analyzer:
   exclude: [test/*.mocks.dart]
 
-linter:   
-  rules: 
-    no_leading_underscores_for_local_identifiers: false
+  errors:
+    deprecated_member_use_from_same_package: ignore
 
+linter:
+  rules:
+    no_leading_underscores_for_local_identifiers: false


### PR DESCRIPTION
It makes sense to ignore warning from deprecated_member_use_from_same_package for packages.
Also remove trailing spaces.